### PR TITLE
Workaround for broken GitLab API

### DIFF
--- a/marge/merge_request.py
+++ b/marge/merge_request.py
@@ -121,7 +121,9 @@ class MergeRequest(gitlab.Resource):
             '/projects/{0.project_id}/merge_requests/{0.iid}/merge'.format(self),
             dict(
                 should_remove_source_branch=remove_branch,
-                merge_when_pipeline_succeeds=True,
+                # TODO(bsima): change to True when gitlab is next released with this fixed:
+                # https://gitlab.com/gitlab-org/gitlab/issues/121620
+                merge_when_pipeline_succeeds=False,
                 sha=sha or self.sha,  # if provided, ensures what is merged is what we want (or fails)
             ),
         ))


### PR DESCRIPTION
This issue https://gitlab.com/gitlab-org/gitlab/issues/121620 is causing marge-bot to fail when it tries to merge.

That issue is fixed, but not in any released gitlab version:

```
[bsima@bsima:~/src/gitlab] 2020.01.15..14.48
$ git branch --contains c786bbdb18f53d009148075e592cd776f56e3876
* master

[bsima@bsima:~/src/gitlab] 2020.01.15..14.49
$ git tag --contains c786bbdb18f53d009148075e592cd776f56e3876
```

When gitlab releases that commit, we can revert this change.